### PR TITLE
에디터 서버사이드 API 코드 리팩토링 (editorRouter.ts, editorController.ts 파일 등) 

### DIFF
--- a/client/src/components/editor/AlgoHeaderTab.tsx
+++ b/client/src/components/editor/AlgoHeaderTab.tsx
@@ -14,12 +14,12 @@ function AlgoHeaderTab(props) {
   const { bojProbDataRef, setBojProbFullData, setBojProblemId } = props;
 
   /* 서버로 몽고DB에 저장된 백준 문제 전체 정보 요청 */
-  async function fetchBojProbFullData(probId: string) {
+  async function showBojProbDataById(probId: string) {
     if (bojProbDataRef.current === null) return;
 
     try {
       const response = await axios.get(
-        `${APPLICATION_EDITOR_URL}/bojdata?probId=${probId}`
+        `${APPLICATION_EDITOR_URL}/boj_prob_data?probId=${probId}`
       );
 
       setBojProblemId(parseInt(probId));
@@ -53,7 +53,7 @@ function AlgoHeaderTab(props) {
   //     let probData = response.data;
   //     console.log(probData);
   //     setBojProbData(probData);
-  //     fetchBojProbFullData(probId);
+  //     showBojProbDataById(probId);
   //   } catch (error) {
   //     console.error(error);
   //   }
@@ -89,7 +89,7 @@ function AlgoHeaderTab(props) {
   const handleKeyDown = (event) => {
     if (event.key === 'Enter') {
       let probId = bojProbDataRef.current.value;
-      fetchBojProbFullData(probId);
+      showBojProbDataById(probId);
     }
   };
 

--- a/client/src/components/editor/EvaluateButton.tsx
+++ b/client/src/components/editor/EvaluateButton.tsx
@@ -50,9 +50,9 @@ function EvaluateButton(props) {
 
   /* 유저가 가채점 성공시 소켓 이벤트 발동 */
   const broadcastSuccess = () => {
-    mySocket?.emit('Big Deal', {
+    mySocket?.emit('broadcastSuccess', {
       editorName: editorName,
-      problemId: bojProblemId || 19939,
+      problemId: bojProblemId,
       broadcast: true,
     });
   };

--- a/client/src/components/editor/ProbSearchModal.tsx
+++ b/client/src/components/editor/ProbSearchModal.tsx
@@ -45,6 +45,7 @@ export default function SearchModal(props: any) {
   const [pagedProbData, setPagedProbData] = useState('');
   const [totalPages, setTotalPages] = useState(0);
   let page = 1;
+  const limit = 12;
 
   /* DB에 저장된 백준 문제 정보를 페이징하여 요청 */
   async function showFilteredBojProbData(filter: any, page: number) {
@@ -56,6 +57,7 @@ export default function SearchModal(props: any) {
         {
           probQuery: filter,
           page: page,
+          limit: limit,
         }
       );
 
@@ -68,8 +70,7 @@ export default function SearchModal(props: any) {
     }
   }
 
-  const handlePageChange = async (pageNumber: number) => {
-    page = pageNumber;
+  const handlePageChange = async (page: number) => {
     await showFilteredBojProbData(filter, page);
   };
 
@@ -123,7 +124,7 @@ export default function SearchModal(props: any) {
                   fontSize="large"
                   onClick={() => {
                     console.log(filter);
-                    showFilteredBojProbData(filter, 1); // 필터를 만족하는 DB 자료들 fetch
+                    showFilteredBojProbData(filter, page); // 필터를 만족하는 DB 자료들 fetch
                   }}
                 />
               </ListItemIcon>

--- a/client/src/components/editor/ProbSearchModal.tsx
+++ b/client/src/components/editor/ProbSearchModal.tsx
@@ -66,9 +66,9 @@ export default function SearchModal(props: any) {
     }
   }
 
-  const handlePageChange = (pageNumber: number) => {
+  const handlePageChange = async (pageNumber: number) => {
     page = pageNumber;
-    fetchFilteredData(filter, page);
+    await fetchFilteredData(filter, page);
   };
 
   // useEffect(() => {

--- a/client/src/components/editor/ProbSearchModal.tsx
+++ b/client/src/components/editor/ProbSearchModal.tsx
@@ -45,7 +45,7 @@ export default function SearchModal(props: any) {
   const [pagedProbData, setPagedProbData] = useState('');
   const [totalPages, setTotalPages] = useState(0);
   let page = 1;
-  const limit = 12;
+  const limit = 10;
 
   /* DB에 저장된 백준 문제 정보를 페이징하여 요청 */
   async function showFilteredBojProbData(filter: any, page: number) {

--- a/client/src/components/editor/ProbSearchModal.tsx
+++ b/client/src/components/editor/ProbSearchModal.tsx
@@ -46,16 +46,18 @@ export default function SearchModal(props: any) {
   const [totalPages, setTotalPages] = useState(0);
   let page = 1;
 
-  /* 서버로 몽고DB에 저장된 백준 문제 정보 요청 */
-  async function fetchFilteredData(filter: any, page: number) {
+  /* DB에 저장된 백준 문제 정보를 페이징하여 요청 */
+  async function showFilteredBojProbData(filter: any, page: number) {
     if (filter === null || filter === '') return;
-    console.log(page, '페이지 자료 가져와줘');
 
     try {
-      const response = await axios.post(`${APPLICATION_EDITOR_URL}/probdata`, {
-        data: filter,
-        page: page,
-      });
+      const response = await axios.post(
+        `${APPLICATION_EDITOR_URL}/filtered_prob_data`,
+        {
+          probQuery: filter,
+          page: page,
+        }
+      );
 
       console.log(response.data.message);
       setPagedProbData(response.data.payload.pagedDocs);
@@ -68,7 +70,7 @@ export default function SearchModal(props: any) {
 
   const handlePageChange = async (pageNumber: number) => {
     page = pageNumber;
-    await fetchFilteredData(filter, page);
+    await showFilteredBojProbData(filter, page);
   };
 
   // useEffect(() => {
@@ -121,7 +123,7 @@ export default function SearchModal(props: any) {
                   fontSize="large"
                   onClick={() => {
                     console.log(filter);
-                    fetchFilteredData(filter, 1); // 필터를 만족하는 DB 자료들 fetch
+                    showFilteredBojProbData(filter, 1); // 필터를 만족하는 DB 자료들 fetch
                   }}
                 />
               </ListItemIcon>

--- a/client/src/components/editor/autocomplete.tsx
+++ b/client/src/components/editor/autocomplete.tsx
@@ -1,6 +1,21 @@
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 
+interface AlgoFilterOptions {
+  source?: string;
+  'solvedAC.level'?: string;
+}
+
+const algoFilterOptions: AlgoFilterOptions[] = [
+  { 'solvedAC.level': '브론즈' },
+  { 'solvedAC.level': '실버' },
+  { 'solvedAC.level': '골드' },
+  { 'solvedAC.level': '플래티넘' },
+  { 'solvedAC.level': '다이아몬드' },
+  { 'solvedAC.level': '루비' },
+  { source: '한국정보올림피아드' },
+];
+
 export default function LimitTags(props: any) {
   const { setFilter } = props;
 
@@ -10,7 +25,9 @@ export default function LimitTags(props: any) {
       limitTags={2}
       id="multiple-limit-tags"
       options={algoFilterOptions}
-      getOptionLabel={(option) => option.tag}
+      getOptionLabel={(option: AlgoFilterOptions) =>
+        Object.values(option)[0] || ''
+      }
       renderInput={(params) => (
         <TextField {...params} placeholder="검색 필터 추가" />
       )}
@@ -25,20 +42,3 @@ export default function LimitTags(props: any) {
     />
   );
 }
-
-const algoFilterOptions = [
-  // { tag: '백준' },
-  // { tag: '리트코드' },
-  { tag: '브론즈' },
-  { tag: '실버' },
-  { tag: '골드' },
-  { tag: '플래티넘' },
-  { tag: '다이아몬드' },
-  { tag: '루비' },
-  { tag: '난이도 없음' },
-  // { tag: 'easy' },
-  // { tag: 'medium' },
-  // { tag: 'difficult' },
-  // { tag: '채점가능' },
-  { tag: '한국정보올림피아드' },
-];

--- a/client/src/components/editor/autocomplete.tsx
+++ b/client/src/components/editor/autocomplete.tsx
@@ -9,7 +9,7 @@ export default function LimitTags(props: any) {
       multiple
       limitTags={2}
       id="multiple-limit-tags"
-      options={algoFilter}
+      options={algoFilterOptions}
       getOptionLabel={(option) => option.tag}
       renderInput={(params) => (
         <TextField {...params} placeholder="검색 필터 추가" />
@@ -26,7 +26,7 @@ export default function LimitTags(props: any) {
   );
 }
 
-const algoFilter = [
+const algoFilterOptions = [
   // { tag: '백준' },
   // { tag: '리트코드' },
   { tag: '브론즈' },

--- a/client/src/scenes/Mainscene.tsx
+++ b/client/src/scenes/Mainscene.tsx
@@ -327,11 +327,10 @@ export default class MainScene extends Phaser.Scene {
     this.whiteboardButton.scale *= 0.65;
     this.whiteboardButton.setVisible(false);
 
-    // Listen for the "Big Deal" event on the client side
-    phaserGame.socket?.on('Big Deal', (payload) => {
+    /* Listen for the "broadcastSuccess" event from other clients */
+    phaserGame.socket?.on('broadcastSuccess', (payload) => {
       showSuccessToast(payload.editorName, payload.problemId);
       newHitSoundToggle();
-      /* If player solve a problem, turn the solved effect on */
       this.showProblemSolvedEffect(payload.editorName);
     });
 

--- a/server/controllers/editorController.ts
+++ b/server/controllers/editorController.ts
@@ -11,6 +11,17 @@ import { Prob } from '../models/Prob';
 const CLIENT_ID = process.env.JDOODLE_CLIENT_ID;
 const CLIENT_SECRET = process.env.JDOODLE_CLIENT_SECRET;
 
+/* define interfaces */
+interface ProbQueryItem {
+  tag: string;
+}
+
+interface ProbFilter {
+  platform?: string;
+  'solvedAC.level'?: number | object;
+  source?: string;
+}
+
 /* create the data to be sent to the JDoodle API */
 const createProgramData = (codeToRun: string, stdin: string) => {
   return {
@@ -77,18 +88,19 @@ export const getBojProbDataById = async (req: Request, res: Response) => {
 };
 
 /* get response for fetching filtered paginated data */
-export const getProbData = async (req: Request, res: Response) => {
-  const probQuery = req?.body.data;
-  const page = req?.body.page;
+export const getFilteredBojProbDataByPage = async (
+  req: Request,
+  res: Response
+) => {
+  const probQuery: ProbQueryItem[] = req?.body.probQuery;
+  const page: number = req?.body.page;
   // console.log(req?.body);
 
-  let probFilter = {};
+  let probFilter: ProbFilter = {};
 
-  //@ts-ignore
   probQuery.forEach((value, index) => {
     console.log(value.tag, index);
     if (['백준', '리트코드'].includes(value.tag)) {
-      //@ts-ignore
       probFilter['platform'] = value.tag;
     } else if (
       [
@@ -124,10 +136,8 @@ export const getProbData = async (req: Request, res: Response) => {
         default:
           condition = 0;
       }
-      //@ts-ignore
       probFilter['solvedAC.level'] = condition;
     } else if (['한국정보올림피아드'].includes(value.tag)) {
-      //@ts-ignore
       probFilter['source'] = value.tag;
     }
   });

--- a/server/controllers/editorController.ts
+++ b/server/controllers/editorController.ts
@@ -73,7 +73,7 @@ export const compileCode = async (req: Request, res: Response) => {
   }
 };
 
-/* get response for fetching boj problem data by its id */
+/* fetch boj problem data by its id */
 export const getBojProbDataById = async (req: Request, res: Response) => {
   try {
     const data = await Prob.find({ probId: req?.query?.probId });
@@ -90,7 +90,7 @@ export const getBojProbDataById = async (req: Request, res: Response) => {
   }
 };
 
-/* process the filter input to proper mongoose query */
+/* process the filtering tags to proper mongoose query */
 const processFilterInput = (probQuery: ProbQueryItem[]) => {
   let probFilter: ProbFilter = {};
   probQuery.forEach((query) => {
@@ -162,16 +162,14 @@ const paginateFilteredResult = async (
   }
 };
 
-/* get response for fetching filtered paginated data */
+/* fetch paginated and filtered boj problems */
 export const getFilteredBojProbDataByPage = async (
   req: Request,
   res: Response
 ) => {
-  const probQuery: ProbQueryItem[] = req?.body.probQuery;
-  const page: number = req?.body.page;
-  const limit: number = req?.body.limit;
+  const { probQuery, page, limit } = req.body;
 
-  const probFilter: ProbFilter = processFilterInput(probQuery);
+  const probFilter = processFilterInput(probQuery);
   const sort = { probId: 'asc' };
 
   try {

--- a/server/controllers/editorController.ts
+++ b/server/controllers/editorController.ts
@@ -61,8 +61,8 @@ export const compileCode = async (req: Request, res: Response) => {
   }
 };
 
-/* get response for fetching boj problem data */
-export const getBojProbData = async (req: Request, res: Response) => {
+/* get response for fetching boj problem data by its id */
+export const getBojProbDataById = async (req: Request, res: Response) => {
   const uri = `mongodb+srv://juncheol:${mongoPassword}@cluster0.v0izvl3.mongodb.net/?retryWrites=true&w=majority`;
   const client = new MongoClient(uri, {
     useNewUrlParser: true,

--- a/server/controllers/editorController.ts
+++ b/server/controllers/editorController.ts
@@ -152,6 +152,7 @@ const paginateFilteredResult = async (
   };
 
   try {
+    //@ts-ignore
     const result = await Prob.paginate(probFilter, options);
     const data = {
       status: 200,

--- a/server/controllers/editorController.ts
+++ b/server/controllers/editorController.ts
@@ -116,39 +116,49 @@ const processFilterInput = (probQuery: ProbQueryItem[]) => {
   return probFilter;
 };
 
+const createPagingOptions = (page: number, limit: number, sort: object) => ({
+  page,
+  limit,
+  sort,
+});
+
+const createPagingData = (
+  status: number,
+  message: string,
+  docs: any[] = [],
+  totalPages: number = 0
+) => ({
+  status,
+  message,
+  payload: { pagedDocs: docs, totalPages: totalPages },
+});
+
 const paginateFilteredResult = async (
   probFilter: ProbFilter,
   page: number,
   limit: number,
   sort: object
 ) => {
-  const options = {
-    page: page,
-    limit: limit,
-    sort: sort,
-  };
+  const options = createPagingOptions(page, limit, sort);
 
   try {
     //@ts-ignore
     const result = await Prob.paginate(probFilter, options);
-    const data = {
-      status: 200,
-      message: 'problems found',
-      payload: { pagedDocs: result.docs, totalPages: result.totalPages },
-    };
+    let data = createPagingData(
+      200,
+      'problems found',
+      result.docs,
+      result.totalPages
+    );
 
     // 검색 결과가 없는 경우
     if (!data.payload.pagedDocs.length) {
-      data.status = 404;
-      data.message = 'problems not found';
+      data = createPagingData(404, 'problems not found');
     }
     return data;
   } catch (err) {
     console.log(err);
-    return {
-      status: 500,
-      message: 'An error occurred while paginating result',
-    };
+    return createPagingData(500, 'An error occurred while paginating result');
   }
 };
 

--- a/server/controllers/propTypes.ts
+++ b/server/controllers/propTypes.ts
@@ -1,13 +1,3 @@
-// export type Token = string;
-
-// export interface IUserInfo {
-//   userId: string;
-//   userPw: string;
-//   userNickname: string;
-//   userBojId?: string;
-//   userLeetId?: string;
-// }
-
 export type Token = string;
 
 export interface IProbInfo {

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,6 @@ dotenv.config();
 import express, { Express, Request, Response } from 'express';
 import cors from 'cors';
 import http from 'http'; // Load in http module
-import pkg from 'body-parser';
 import mongoose from 'mongoose';
 import { Socket, Server } from 'socket.io'; // Load in socket.io
 import editorServer from './servers/editorServer';
@@ -24,10 +23,9 @@ import MicMuteInfo from './services/MicMuteInfo';
 
 const port = process.env.PORT || 8080;
 const mongoPassword = process.env.MONGO_PW;
-const { json } = pkg;
 
 const app: Express = express();
-app.use(json());
+app.use(express.json());
 app.use(cors());
 app.use(cookieParser());
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -271,11 +271,9 @@ io.on('connection', (socket: Socket) => {
     socket.broadcast.emit('changePlayerCollider', payLoad);
   });
 
-  // Listen for the "Big Deal" event on the client side
-  socket.on('Big Deal', (payload) => {
-    console.log(`${payload.editorName}`);
-    // socket.broadcast.emit('Big Deal', payload);
-    io.emit('Big Deal', payload);
+  /* Listen for an event of success on quiz from the client side */
+  socket.on('broadcastSuccess', (payload) => {
+    io.emit('broadcastSuccess', payload);
   });
 
   socket.on('sendEmoji', (payload) => {

--- a/server/models/Prob.ts
+++ b/server/models/Prob.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Document, Model } from 'mongoose';
-import { IProbInfo } from '../controllers/propTyes';
+import { IProbInfo } from '../controllers/propTypes';
 const mongoosePaginate = require('mongoose-paginate-v2');
 
 const probdata = new Schema<IProbInfo>({
@@ -29,7 +29,6 @@ const probdata = new Schema<IProbInfo>({
 probdata.plugin(mongoosePaginate);
 
 const Prob = model<IProbDocument>('prob', probdata);
-// create new User document
 
 export interface IProbDocument extends IProbInfo, Document {}
 export interface IProbModel extends Model<IProbDocument> {}

--- a/server/models/Prob.ts
+++ b/server/models/Prob.ts
@@ -1,6 +1,6 @@
 import { Schema, model, Document, Model } from 'mongoose';
 import { IProbInfo } from '../controllers/propTypes';
-const mongoosePaginate = require('mongoose-paginate-v2');
+import mongoosePaginate from 'mongoose-paginate-v2';
 
 const probdata = new Schema<IProbInfo>({
   probId: {

--- a/server/routes/editorRouter.ts
+++ b/server/routes/editorRouter.ts
@@ -13,7 +13,7 @@ router.get('/', origin);
 /* "코드 실행하기" 요청에 보내는 응답 */
 router.post('/code_to_run', compileCode);
 
-/* 백준 문제 번호로 몽고DB 쿼리에 대한 응답 */
+/* 백준 문제 번호를 이용한 몽고DB 쿼리 응답 */
 router.get('/boj_prob_data', getBojProbDataById);
 
 /* 백준 문제 필터링 몽고DB 요청에 보내는 응답 */

--- a/server/routes/editorRouter.ts
+++ b/server/routes/editorRouter.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import {
   compileCode,
   getBojProbDataById,
-  getProbData,
+  getFilteredBojProbDataByPage,
   origin,
 } from '../controllers/editorController';
 
@@ -17,6 +17,6 @@ router.post('/code_to_run', compileCode);
 router.get('/boj_prob_data', getBojProbDataById);
 
 /* 백준 문제 필터링 몽고DB 요청에 보내는 응답 */
-router.post('/probdata', getProbData);
+router.post('/filtered_prob_data', getFilteredBojProbDataByPage);
 
 export default router;

--- a/server/routes/editorRouter.ts
+++ b/server/routes/editorRouter.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import {
   compileCode,
-  getBojProbData,
+  getBojProbDataById,
   getProbData,
   origin,
 } from '../controllers/editorController';
@@ -14,7 +14,7 @@ router.get('/', origin);
 router.post('/code_to_run', compileCode);
 
 /* 백준 문제 번호로 몽고DB 쿼리에 대한 응답 */
-router.get('/bojdata', getBojProbData);
+router.get('/boj_prob_data', getBojProbDataById);
 
 /* 백준 문제 필터링 몽고DB 요청에 보내는 응답 */
 router.post('/probdata', getProbData);

--- a/server/servers/dbServer.ts
+++ b/server/servers/dbServer.ts
@@ -2,15 +2,13 @@ import express, { Express, Request, Response } from 'express';
 import http from 'http';
 import cors from 'cors';
 // import editorRouter from '../routes/editorRouter';
-import pkg from 'body-parser';
 import userRouter from '../routes/userRouter';
 import whiteboardRouter from '../routes/whiteboardRouter';
 
 const app: Express = express();
 const server = http.createServer(app);
-const { json } = pkg;
 
-app.use(json());
+app.use(express.json());
 app.use(cors());
 
 app.use('/user', userRouter);

--- a/server/servers/editorServer.ts
+++ b/server/servers/editorServer.ts
@@ -2,13 +2,11 @@ import express, { Express, Request, Response } from 'express';
 import http from 'http';
 import cors from 'cors';
 import editorRouter from '../routes/editorRouter';
-import pkg from 'body-parser';
 
 const app: Express = express();
 const server = http.createServer(app);
-const { json } = pkg;
 
-app.use(json());
+app.use(express.json());
 app.use(cors());
 
 app.use('/', editorRouter);

--- a/server/servers/scrapingserver/scraping_test.py
+++ b/server/servers/scrapingserver/scraping_test.py
@@ -1,68 +1,68 @@
-import os
-import time
-from pymongo import MongoClient
-import json
-from bs4 import BeautifulSoup
-import requests
-from dotenv import load_dotenv
-# load .env
-load_dotenv()
+# import os
+# import time
+# from pymongo import MongoClient
+# import json
+# from bs4 import BeautifulSoup
+# import requests
+# from dotenv import load_dotenv
+# # load .env
+# load_dotenv()
 
-mongoPassword = os.environ.get('MONGO_PW')
+# mongoPassword = os.environ.get('MONGO_PW')
 
-client = MongoClient(
-    f'mongodb+srv://juncheol:{mongoPassword}@cluster0.v0izvl3.mongodb.net/?retryWrites=true&w=majority')
-db = client.codewart
-collection = db.probs
+# client = MongoClient(
+#     f'mongodb+srv://juncheol:{mongoPassword}@cluster0.v0izvl3.mongodb.net/?retryWrites=true&w=majority')
+# db = client.codewart
+# collection = db.probs
 
-# 백준 서버에 요청
-headers = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36'}
-s = 25401    # 시작문제넘버
-e = 27493    # 종료문제넘버
+# # 백준 서버에 요청
+# headers = {
+#     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36'}
+# s = 25401    # 시작문제넘버
+# e = 27493    # 종료문제넘버
 
-for num in range(s, e+1):
-    probId = num
-    data = requests.get(
-        f'https://www.acmicpc.net/problem/{probId}', headers=headers)
-    soup = BeautifulSoup(data.text, 'html.parser')
+# for num in range(s, e+1):
+#     probId = num
+#     data = requests.get(
+#         f'https://www.acmicpc.net/problem/{probId}', headers=headers)
+#     soup = BeautifulSoup(data.text, 'html.parser')
 
-    try:
-        prob_desc = soup.select_one('#problem_description').get_text()
-    except:
-        continue
-    try:
-        prob_input = soup.select_one('#problem_input').get_text()
-    except:
-        prob_input = ''
-    try:
-        prob_output = soup.select_one('#problem_output').get_text()
-    except:
-        prob_output = ''
-    try:
-        source = soup.select_one('#source > p > a:nth-child(2)').get_text()
-    except:
-        source = ''
+#     try:
+#         prob_desc = soup.select_one('#problem_description').get_text()
+#     except:
+#         continue
+#     try:
+#         prob_input = soup.select_one('#problem_input').get_text()
+#     except:
+#         prob_input = ''
+#     try:
+#         prob_output = soup.select_one('#problem_output').get_text()
+#     except:
+#         prob_output = ''
+#     try:
+#         source = soup.select_one('#source > p > a:nth-child(2)').get_text()
+#     except:
+#         source = ''
 
-    samples = {}
-    for i in range(1, 50):
-        inputval = soup.select_one(f'#sample-input-{i}')
-        if (inputval == None):
-            break
-        else:
-            outputval = soup.select_one(f'#sample-output-{i}')
-            samples[str(i)] = {"input": inputval.get_text(),
-                               "output": outputval.get_text()}
-            i += 1
+#     samples = {}
+#     for i in range(1, 50):
+#         inputval = soup.select_one(f'#sample-input-{i}')
+#         if (inputval == None):
+#             break
+#         else:
+#             outputval = soup.select_one(f'#sample-output-{i}')
+#             samples[str(i)] = {"input": inputval.get_text(),
+#                                "output": outputval.get_text()}
+#             i += 1
 
-    crawled_data = {
-        "probId": probId,
-        "prob_desc": prob_desc,
-        "prob_input": prob_input,
-        "prob_output": prob_output,
-        "samples": samples,
-        "source": source
-    }
+#     crawled_data = {
+#         "probId": probId,
+#         "prob_desc": prob_desc,
+#         "prob_input": prob_input,
+#         "prob_output": prob_output,
+#         "samples": samples,
+#         "source": source
+#     }
 
-    # DB에 삽입하기
-    collection.insert_one(crawled_data)
+#     # DB에 삽입하기
+#     collection.insert_one(crawled_data)

--- a/server/servers/scrapingserver/updating_bojdb.py
+++ b/server/servers/scrapingserver/updating_bojdb.py
@@ -1,66 +1,66 @@
-import os
-import time
-from pymongo import MongoClient
-import json
-from bs4 import BeautifulSoup
-import requests
-from dotenv import load_dotenv
-# load .env
+# import os
+# import time
+# from pymongo import MongoClient
+# import json
+# from bs4 import BeautifulSoup
+# import requests
+# from dotenv import load_dotenv
+# # load .env
 
 
-mongoPassword = os.environ.get('MONGO_PW')
+# mongoPassword = os.environ.get('MONGO_PW')
 
 
-client = MongoClient(
-    f'mongodb+srv://juncheol:{mongoPassword}@cluster0.v0izvl3.mongodb.net/?retryWrites=true&w=majority')
-db = client.codewart
-collection = db.probs
+# client = MongoClient(
+#     f'mongodb+srv://juncheol:{mongoPassword}@cluster0.v0izvl3.mongodb.net/?retryWrites=true&w=majority')
+# db = client.codewart
+# collection = db.probs
 
-# 백준 서버에 요청
-headers = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36'}
-s = 19482    # 시작문제넘버
-e = 19999    # 종료문제넘버
+# # 백준 서버에 요청
+# headers = {
+#     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36'}
+# s = 19482    # 시작문제넘버
+# e = 19999    # 종료문제넘버
 
-miss = []
+# miss = []
 
-for num in range(s, e+1):
-    data2 = requests.get(
-        f'https://solved.ac/api/v3/problem/show?problemId={num}', headers=headers)
+# for num in range(s, e+1):
+#     data2 = requests.get(
+#         f'https://solved.ac/api/v3/problem/show?problemId={num}', headers=headers)
 
-    if (data2.status_code != 200):
-        miss.append(num)
-        if (data2.status_code == 429):
-            print(num, ":", "too many requests")
-            break
-        else:
-            print(num, ":", "something is wrong")
-        continue
+#     if (data2.status_code != 200):
+#         miss.append(num)
+#         if (data2.status_code == 429):
+#             print(num, ":", "too many requests")
+#             break
+#         else:
+#             print(num, ":", "something is wrong")
+#         continue
 
-    # Convert byte string to regular string
-    data2_dict = json.loads(data2.text)
+#     # Convert byte string to regular string
+#     data2_dict = json.loads(data2.text)
 
-    # define the filter for the document to update
-    filters = {"probId": num}
+#     # define the filter for the document to update
+#     filters = {"probId": num}
 
-    # define the update operation
-    update = {"$set": {"solvedAC": data2_dict}}
+#     # define the update operation
+#     update = {"$set": {"solvedAC": data2_dict}}
 
-    # DB에 업데이트하기
-    result = collection.update_one(filters, update)
+#     # DB에 업데이트하기
+#     result = collection.update_one(filters, update)
 
-    # print the result of the update operation
-    print(num, ":", result.modified_count)
-    # time.sleep(1)
+#     # print the result of the update operation
+#     print(num, ":", result.modified_count)
+#     # time.sleep(1)
 
 
-print(miss)
+# print(miss)
 
-# crawled_data = {
-# "probId":probId,
-# "prob_desc" : prob_desc,
-# "prob_input" : prob_input,
-# "prob_output" : prob_output,
-# "samples" : samples,
-# "source" : source
-# }
+# # crawled_data = {
+# # "probId":probId,
+# # "prob_desc" : prob_desc,
+# # "prob_input" : prob_input,
+# # "prob_output" : prob_output,
+# # "samples" : samples,
+# # "source" : source
+# # }


### PR DESCRIPTION
에디터 서버사이드 API 코드의 상당 부분을 리팩토링 하였습니다. 
프로젝트 진행하면서 아쉬웠던 부분을 수정하고, 가독성을 높이고 유지보수를 더 용이하게 하기 위함입니다. 

## 작업 내용
- 중복 DB 연결 제거: 에디터 측에서 알고리즘 문제 쿼리 요청시 새로운 DB 연결 객체를 생성하지 않고 이미 연결한 DB 인스턴스를 그대로 사용하도록 수정
- API 코드 추상화 및 세분화: 기능에 따라 기존 함수를 여러 개의 서브함수들로 나누어 가독성을 높이고 유지보수 용이하게끔 수정 
- 주석 및 변수명 개선: 기존의 모호하던 API 엔드포인트 네이밍이나 그 밖의 변수명과 주석을 더 직관적이도록 수정
- 타입스크립트 에러 개선
